### PR TITLE
Add loading.tsx boundaries to dashboard routes

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/src/app/dashboard/bookings/loading.tsx
+++ b/src/app/dashboard/bookings/loading.tsx
@@ -1,0 +1,14 @@
+import { BookingEventSkeleton, CalendarSkeleton } from "@/components/skeletons";
+
+export default function Loading() {
+  return (
+    <div className="@container">
+      <div className="flex flex-col @4xl:grid @4xl:grid-cols-3 w-full gap-6">
+        <CalendarSkeleton />
+        <div className="@container relative grow bg-background p-6">
+          <BookingEventSkeleton />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/loading.tsx
+++ b/src/app/dashboard/loading.tsx
@@ -1,0 +1,5 @@
+import { DashboardSkeleton } from "@/components/skeletons";
+
+export default function Loading() {
+  return <DashboardSkeleton />;
+}

--- a/src/app/dashboard/statistics/loading.tsx
+++ b/src/app/dashboard/statistics/loading.tsx
@@ -1,0 +1,5 @@
+import { StatisticsSkeleton } from "@/components/skeletons";
+
+export default function Loading() {
+  return <StatisticsSkeleton />;
+}

--- a/src/components/skeletons.tsx
+++ b/src/components/skeletons.tsx
@@ -23,3 +23,46 @@ export function BookingEventSkeleton() {
     </div>
   )
 }
+
+export function StatisticsSkeleton() {
+  return (
+    <div className="animate-pulse">
+      <header className="bg-primary pt-safe-top">
+        <div className="p-6 pb-10 flex items-end">
+          <span className="h-9 w-40 rounded bg-white/30"></span>
+        </div>
+      </header>
+      <div className="relative bg-primary px-6 pb-12">
+        <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 lg:gap-6 pt-6">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="flex flex-col gap-3 rounded-2xl bg-white p-3">
+              <span className="h-5 w-24 rounded bg-gray-100"></span>
+              <span className="h-8 w-16 rounded bg-gray-100"></span>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="relative z-[2]">
+        <div className="bg-background h-6 rounded-t-3xl -mt-6"></div>
+        <div className="bg-background p-6 pt-0 flex flex-col gap-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="h-12 rounded-lg bg-gray-100"></div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function DashboardSkeleton() {
+  return (
+    <div className="flex flex-col gap-6 p-6 max-lg:pb-[6.5rem] animate-pulse">
+      <div className="h-40 w-full rounded-3xl bg-gray-100"></div>
+      <div className="flex flex-col gap-3">
+        <div className="h-24 w-full rounded-2xl bg-gray-100"></div>
+        <div className="h-24 w-full rounded-2xl bg-gray-100"></div>
+        <div className="h-24 w-full rounded-2xl bg-gray-100"></div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Why
Dashboard navigation felt slow / unresponsive compared to the old SPA. Root cause: there were **no `loading.tsx` Suspense boundaries**, so clicking a nav `Link` blocked on the full Server Component render — including Prisma queries — before anything on screen changed.

## What
Adds loading boundaries so the shell swaps **instantly** and data streams in:

- `dashboard/loading.tsx` — generic fallback (index, admin, menu, profile, settings)
- `dashboard/statistics/loading.tsx` — hero + 4 stat tiles + table skeleton
- `dashboard/bookings/loading.tsx` — calendar + booking-event skeletons (covers calendar & list)
- `skeletons.tsx` — adds `StatisticsSkeleton` + `DashboardSkeleton`, reusing the existing `animate-pulse` / `bg-gray-100` idiom
- `.npmrc` (`legacy-peer-deps=true`) — installs resolve cleanly with React 19 + `react-big-calendar` (rides along; was needed to install deps)

## Verification
- `tsc --noEmit` clean on all changed files (the 20 remaining errors are pre-existing, in untouched files, swallowed by `ignoreBuildErrors`).
- Not driven end-to-end in a browser yet — needs an authenticated Clerk session locally.

## Notes
- This is the first of the perf fixes tracked on the board. Follow-ups: #4 (remove server-side `getDeviceType()`/`headers()` detection), #5 (redundant `currentUser()` + parallelize), #6 (service worker caching).

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)