### PR TITLE
Remove redundant currentUser() calls and parallelize data fetching

### DIFF
--- a/src/app/dashboard/booking/[id]/edit/page.tsx
+++ b/src/app/dashboard/booking/[id]/edit/page.tsx
@@ -7,8 +7,10 @@ import { currentUser } from "@clerk/nextjs/server";
 export default async function UpdateBookingPage(props: { params: Promise<{ id: string }> }) {
   const params = await props.params;
   const id = params.id;
-  const booking = await fetchBooking(id);
-  const user = await currentUser();
+  const [booking, user] = await Promise.all([
+    fetchBooking(id),
+    currentUser(),
+  ]);
 
   return (
       <>

--- a/src/app/dashboard/booking/[id]/page.tsx
+++ b/src/app/dashboard/booking/[id]/page.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button";
 import { getRoomName, showGuests, showNiceDates } from "@/lib/functions";
 import { prisma } from "@/lib/prisma";
 import { getBookingName } from "@/lib/utils";
-import { currentUser } from "@clerk/nextjs/server";
+import { auth } from "@clerk/nextjs/server";
 import { notFound } from "next/navigation";
 import { CancelBookingDialog } from "../../../../components/modal/cancel-booking";
 import Link from "next/link";
@@ -15,7 +15,7 @@ export default async function UniqueBookingPage(props: {
 }) {
   const params = await props.params;
   const id = params.id;
-  const user = await currentUser();
+  const { userId } = await auth();
   const booking = await prisma.booking.findUnique({
     where: {
       id: id,
@@ -34,7 +34,7 @@ export default async function UniqueBookingPage(props: {
     return notFound();
   }
   const isDepartureNotDatePassed = new Date(booking.departure) > new Date();
-  const loggedInUserIsAsSameAsBookingOwner = user?.id === booking.user_id;
+  const loggedInUserIsAsSameAsBookingOwner = userId === booking.user_id;
 
   return (
     <Main>

--- a/src/app/dashboard/bookings/(calendar)/modal/(..)booking/[id]/page.tsx
+++ b/src/app/dashboard/bookings/(calendar)/modal/(..)booking/[id]/page.tsx
@@ -14,7 +14,7 @@ import Link from "next/link";
 import { prisma } from "@/lib/prisma";
 import Avatar from "@/components/avatar";
 import { NiceAvatarProps } from "@/components/avatar/types";
-import { currentUser } from "@clerk/nextjs/server";
+import { auth } from "@clerk/nextjs/server";
 
 // Force dynamic page
 export const dynamic = "force-dynamic";
@@ -26,7 +26,7 @@ export default async function UniqueBookingModalPage(props: {
 }) {
   const params = await props.params;
   const id = params.id;
-  const user = await currentUser();
+  const { userId } = await auth();
   const booking = await prisma.booking.findUnique({
     where: {
       id: id,
@@ -47,7 +47,7 @@ export default async function UniqueBookingModalPage(props: {
   }
 
   const isDepartureNotDatePassed = new Date(booking.departure) > new Date();
-  const loggedInUserIsAsSameAsBookingOwner = user?.id === booking.user_id;
+  const loggedInUserIsAsSameAsBookingOwner = userId === booking.user_id;
 
   // Valid
   return (

--- a/src/app/dashboard/bookings/list/modal/(...)booking/[id]/page.tsx
+++ b/src/app/dashboard/bookings/list/modal/(...)booking/[id]/page.tsx
@@ -14,7 +14,7 @@ import Link from "next/link";
 import { prisma } from "@/lib/prisma";
 import Avatar from "@/components/avatar";
 import { NiceAvatarProps } from "@/components/avatar/types";
-import { currentUser } from "@clerk/nextjs/server";
+import { auth } from "@clerk/nextjs/server";
 
 // Force dynamic page
 export const dynamic = "force-dynamic";
@@ -26,7 +26,7 @@ export default async function UniqueBookingModalPage(props: {
 }) {
   const params = await props.params;
   const id = params.id;
-  const user = await currentUser();
+  const { userId } = await auth();
   const booking = await prisma.booking.findUnique({
     where: {
       id: id,
@@ -47,7 +47,7 @@ export default async function UniqueBookingModalPage(props: {
   }
 
   const isDepartureNotDatePassed = new Date(booking.departure) > new Date();
-  const loggedInUserIsAsSameAsBookingOwner = user?.id === booking.user_id;
+  const loggedInUserIsAsSameAsBookingOwner = userId === booking.user_id;
 
   // Valid
   return (

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -10,9 +10,11 @@ import { prisma } from "@/lib/prisma";
 import { currentUser } from "@clerk/nextjs/server";
 
 export default async function DashboardIndex() {
-  const user = await currentUser();
   // const posts = await fetchPosts();
-  const upcomingBookings = await getBookingsDueWithin30Days();
+  const [user, upcomingBookings] = await Promise.all([
+    currentUser(),
+    getBookingsDueWithin30Days(),
+  ]);
 
   return (
     <>

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -7,34 +7,38 @@ import { sortBookingsByYear } from "@/lib/utils";
 import { BookingData } from "@/lib/types";
 import { Main, Section } from "@/components/dashboard/sections";
 import ProfileBookingCard from "@/components/ui/profile-booking-card";
-import { currentUser } from "@clerk/nextjs/server";
+import { auth, currentUser } from "@clerk/nextjs/server";
 import { NiceAvatarProps } from "@/components/avatar/types";
 
 export default async function ProfilePage() {
-  const user = await currentUser();
-  
-  const avatar = await prisma.avatar.findUnique({
-    where: {
-      id: user?.publicMetadata.avatarId as string
-    }
-  })
+  const { userId, sessionClaims } = await auth();
 
-  const bookings = await prisma.booking.findMany({
-    where: {
-      user_id: user?.id,
-      is_test_booking: false,
-    }, 
-    include: {
-      user: {
-        select: {
-          avatar: true
-        }
+  // currentUser() (Clerk profile fetch) is only needed for the display name;
+  // the ids come from the already-verified session, so run all three in parallel.
+  const [user, avatar, bookings] = await Promise.all([
+    currentUser(),
+    prisma.avatar.findUnique({
+      where: {
+        id: sessionClaims?.metadata.avatarId as string
       }
-    },
-    orderBy: {
-      arrival: "desc",
-    }
-  })
+    }),
+    prisma.booking.findMany({
+      where: {
+        user_id: userId as string,
+        is_test_booking: false,
+      },
+      include: {
+        user: {
+          select: {
+            avatar: true
+          }
+        }
+      },
+      orderBy: {
+        arrival: "desc",
+      }
+    }),
+  ]);
 
   const groupedBookings = await sortBookingsByYear(bookings as BookingData[])
   

--- a/src/app/dashboard/start/@modal/(..)booking/[id]/page.tsx
+++ b/src/app/dashboard/start/@modal/(..)booking/[id]/page.tsx
@@ -14,7 +14,7 @@ import Link from "next/link";
 import { prisma } from "@/lib/prisma";
 import Avatar from "@/components/avatar";
 import { NiceAvatarProps } from "@/components/avatar/types";
-import { currentUser } from "@clerk/nextjs/server";
+import { auth } from "@clerk/nextjs/server";
 
 // Force dynamic page
 export const dynamic = "force-dynamic";
@@ -26,7 +26,7 @@ export default async function UniqueBookingModalPage(props: {
 }) {
   const params = await props.params;
   const id = params.id;
-  const user = await currentUser();
+  const { userId } = await auth();
   const booking = await prisma.booking.findUnique({
     where: {
       id: id,
@@ -47,7 +47,7 @@ export default async function UniqueBookingModalPage(props: {
   }
 
   const isDepartureNotDatePassed = new Date(booking.departure) > new Date();
-  const loggedInUserIsAsSameAsBookingOwner = user?.id === booking.user_id;
+  const loggedInUserIsAsSameAsBookingOwner = userId === booking.user_id;
 
   // Valid
   return (

--- a/src/components/dashboard/desktop-nav.tsx
+++ b/src/components/dashboard/desktop-nav.tsx
@@ -1,11 +1,11 @@
 import Link from "next/link";
 import Logo from "@/components/logo";
 import Navigation from "./navigation";
-import { currentUser } from "@clerk/nextjs/server";
+import { auth } from "@clerk/nextjs/server";
 
-export default async function DesktopNav() { 
-  const user = await currentUser();
-  
+export default async function DesktopNav() {
+  const { sessionClaims } = await auth();
+
   return (
     <div className="flex flex-col gap-12">
       <Link
@@ -16,7 +16,7 @@ export default async function DesktopNav() {
           <Logo />
         </div>
       </Link>
-      <Navigation role={user?.publicMetadata.user_role as string} />
+      <Navigation role={sessionClaims?.metadata.user_role as string} />
     </div>
   )
 }

--- a/src/lib/client/notifications/actions.ts
+++ b/src/lib/client/notifications/actions.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { prisma } from "@/lib/prisma";
-import { currentUser } from '@clerk/nextjs/server'
+import { auth } from '@clerk/nextjs/server'
 import webpush, { PushSubscription } from 'web-push';
 
 interface I_SubscribeUser {
@@ -10,16 +10,16 @@ interface I_SubscribeUser {
 }
 
 export async function subscribeUser(props: I_SubscribeUser) {
-	const user = await currentUser()
+	const { userId } = await auth()
 	const { sub, deviceId } = props;
 
-	if (!user?.id) return;
+	if (!userId) return;
 
 	try {
 		const subscribe = await prisma.pushSubscription.create({
 			data: {
 				device_id: deviceId,
-				user_id: user?.id,
+				user_id: userId,
 				value: JSON.stringify(sub),
 			}
 		})


### PR DESCRIPTION
## Summary
`currentUser()` is a network round-trip to Clerk's backend API, issued on top of the middleware `auth()` that already verified the session for the same request. This PR removes that redundant call wherever only the session-verified `userId` or metadata is needed (using `auth()`, which reads the session with no network call), and wraps independent awaits in `Promise.all` to remove request waterfalls.

## Changes
**`currentUser()` → `auth()` (removes a Clerk network round-trip)**
- `booking/[id]/page.tsx` + calendar/list/start modal pages — only compared `user?.id === booking.user_id`; now `userId` from `auth()`
- `desktop-nav.tsx` — only needed the role; now `sessionClaims.metadata.user_role`
- `notifications/actions.ts` (`subscribeUser`) — only needed the id; now `auth().userId`

**Waterfalls → `Promise.all`**
- `dashboard/page.tsx` — `currentUser()` ∥ `getBookingsDueWithin30Days()`
- `booking/[id]/edit/page.tsx` — `fetchBooking(id)` ∥ `currentUser()`
- `profile/page.tsx` — `userId`/`avatarId` pulled from the session, then `currentUser()` (still needed for the display name) ∥ avatar lookup ∥ bookings query, all three in parallel

`booking/create/page.tsx` left unchanged — single await (needs the full profile), no waterfall.

## Note
`profile/page.tsx` and `desktop-nav.tsx` now read `avatarId` / `user_role` from `sessionClaims.metadata` rather than `user.publicMetadata`. This relies on those fields being in the Clerk session token, which the `CustomJwtSessionClaims` type declares and the middleware already depends on (`metadata.onboardingComplete`). Verified locally: avatar renders and nav role is correct.

## Verification
- `tsc --noEmit` clean on touched files
- `npm run build` compiles successfully; all dashboard routes remain dynamic

Closes #5