### PR TITLE
Fetch weather server-side via the new SMHI API

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import Image from "next/image";
 import Weather from "@/components/weather";
 import { Main, Section } from "@/components/dashboard/sections";
@@ -41,7 +42,9 @@ export default async function DashboardIndex() {
             <Typography variant="xl" level="h1" color="text-white">
               Hej {user?.firstName}
             </Typography>
-            <Weather lon="19.039444" lat="57.855" />
+            <Suspense fallback={<p className="text-white text-sm">Laddar väderdata ...</p>}>
+              <Weather lon="19.039444" lat="57.855" />
+            </Suspense>
           </div>
         </div>
         <Main>

--- a/src/components/weather/index.tsx
+++ b/src/components/weather/index.tsx
@@ -1,70 +1,68 @@
-"use client"
-import React, {useEffect, useState} from "react";
+import React from "react";
 import Image from "next/image";
 
 import weatherText from "./weather_text";
 import weatherIcon from "./weather_icon";
 
-interface WeatherData { 
-   name?: string;
-   levelType?: string;
-   level?: number;
-   unit?: string;
-   values?: number[];
-}
-interface WeatherParameters {
-   temp: WeatherData;
-   wsymb: WeatherData;
+interface CurrentForecast {
+   temperature: number;
+   symbol: number;
 }
 
-const Weather = ({lat, lon}: {lat: string, lon: string}) => {
-   const [currentForecast, setCurrentForecast] = useState<WeatherParameters>({temp: {}, wsymb: {}});
-   const [isLoaded, setIsLoaded] = useState(false)
+/**
+ * Fetch the SMHI forecast on the server. SMHI's open-data API sends no CORS
+ * headers, so this must not run in the browser. Cached for an hour since the
+ * forecast doesn't change more often than that.
+ *
+ * Uses the snow1g v1 point-forecast API (the old pmp3g v2 API was retired).
+ * The current temperature is `air_temperature` and the weather symbol is
+ * `symbol_code` (same 1–27 code table the old `Wsymb2` used).
+ */
+async function getCurrentForecast(lat: string, lon: string): Promise<CurrentForecast | null> {
+   try {
+      const response = await fetch(
+         `https://opendata-download-metfcst.smhi.se/api/category/snow1g/version/1/geotype/point/lon/${lon}/lat/${lat}/data.json`,
+         { next: { revalidate: 3600 } }
+      );
 
-   /* eslint-disable  @typescript-eslint/no-explicit-any */
-   const setCurrentForecastObj = (data: any) => {
-      const currentData = data.timeSeries[0];
-      const currentForecast: WeatherParameters = {
-         temp: {},
-         wsymb: {},
+      if (!response.ok) return null;
+
+      const data = await response.json();
+      const current = data?.timeSeries?.[0]?.data;
+
+      if (
+         current == null ||
+         typeof current.air_temperature !== "number" ||
+         typeof current.symbol_code !== "number"
+      ) {
+         return null;
       }
 
-      currentData.parameters.forEach((parameter: WeatherData) => {
-         if (Object.values(parameter).includes("t")) {
-            currentForecast.temp = parameter
-         } else if (Object.values(parameter).includes("Wsymb2")) {
-            currentForecast.wsymb = parameter
-         }
-      });
-
-      setCurrentForecast(currentForecast)
-
+      return { temperature: current.air_temperature, symbol: current.symbol_code };
+   } catch {
+      // SMHI unavailable — fail quietly rather than break the dashboard.
+      return null;
    }
-
-   useEffect(() => {
-      fetch(`https://opendata-download-metfcst.smhi.se/api/category/pmp3g/version/2/geotype/point/lon/${lon}/lat/${lat}/data.json`)
-      .then(response => response.json())
-      .then(data => {
-         setCurrentForecastObj(data)
-         setIsLoaded(true)
-      })
-   }, [lat, lon])
-
-   return (
-      isLoaded ?
-
-      <div className="grid grid-cols-2 gap-2 items-center w-72">
-         <div>
-            <Image src={weatherIcon(currentForecast.wsymb.values![0])} alt="väder" width={50} height={50} className="w-24"/>
-         </div>
-         <div className="text-center pt-4 font-sans">
-            <p className="text-2xl font-bold leading-none text-white">{Math.round(currentForecast.temp.values![0])} &#xb0;C</p>
-            <p className="text-sm text-white">{weatherText(currentForecast.wsymb.values![0])}</p>
-         </div>
-      </div>
-      : <p className="text-white text-sm">Laddar väderdata ...</p> 
-      
-   )
 }
 
-export default Weather
+const Weather = async ({ lat, lon }: { lat: string; lon: string }) => {
+   const forecast = await getCurrentForecast(lat, lon);
+
+   if (!forecast) {
+      return null;
+   }
+
+   return (
+      <div className="grid grid-cols-2 gap-2 items-center w-72">
+         <div>
+            <Image src={weatherIcon(forecast.symbol)} alt="väder" width={50} height={50} className="w-24" />
+         </div>
+         <div className="text-center pt-4 font-sans">
+            <p className="text-2xl font-bold leading-none text-white">{Math.round(forecast.temperature)} &#xb0;C</p>
+            <p className="text-sm text-white">{weatherText(forecast.symbol)}</p>
+         </div>
+      </div>
+   );
+};
+
+export default Weather;


### PR DESCRIPTION
## Summary
The `Weather` component fetched the SMHI forecast directly from the browser and failed. Two problems:
1. SMHI's open-data API sends **no CORS headers**, so any browser `fetch` to it is blocked.
2. The old `pmp3g/version/2` endpoint has been **retired** — it now 404s for every path (including SMHI's own API index and documented example coordinates). The browser reported that 404 as a "CORS error" because the error response also lacks CORS headers.

This PR moves the fetch server-side (no CORS restriction) and migrates to SMHI's replacement API.

## Changes
- **`src/components/weather/index.tsx`** — converted from a `"use client"` component that fetched in `useEffect` to an **async server component**:
  - Server-to-server fetch (no CORS), cached 1h (`{ next: { revalidate: 3600 } }`).
  - New endpoint: `.../api/category/snow1g/version/1/geotype/point/lon/{lon}/lat/{lat}/data.json`.
  - New response shape parsed: `timeSeries[0].data.air_temperature` (temp) and `timeSeries[0].data.symbol_code` (weather symbol). `symbol_code` is the same 1–27 code table the old `Wsymb2` used, so `weatherIcon` / `weatherText` are unchanged.
  - Returns `null` on any failure (bad response / unexpected shape / thrown) so a SMHI outage can't break the dashboard.
- **`src/app/dashboard/page.tsx`** — wrapped `<Weather>` in `<Suspense>` (fallback "Laddar väderdata ...") so the SMHI call streams instead of blocking the page paint.

## Verification
- Live parse check against the new endpoint renders `17°C` for the house coordinates.
- `tsc --noEmit` clean on both files; `npm run build` compiles.
- Works in `next dev` (unlike the SW change), so it's verifiable locally.

Closes #12