### PR TITLE
Await booking form server actions so errors are handled (#15)

### DIFF
--- a/src/components/forms/booking/index.tsx
+++ b/src/components/forms/booking/index.tsx
@@ -80,6 +80,19 @@ export type BookingFormValues = {
 
 const isDevelopment = process.env.NODE_ENV === 'development';
 
+// A server action's redirect() surfaces on the client as a thrown error carrying
+// a "NEXT_REDIRECT" digest. Detect it so we don't mistake a successful redirect
+// for a failure.
+function isRedirectError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "digest" in error &&
+    typeof (error as { digest: unknown }).digest === "string" &&
+    (error as { digest: string }).digest.startsWith("NEXT_REDIRECT")
+  );
+}
+
 export function BookingForm({bookingValues, email, isUpdatingBooking, isCreatingNewBooking}: {bookingValues?: BookingFormValues; email: string | undefined; isUpdatingBooking?: boolean; isCreatingNewBooking?: boolean;}) {
   const [isSending, setIsSending] = useState(false);
   const { selectedDate } = useAppContext();
@@ -305,7 +318,7 @@ export function BookingForm({bookingValues, email, isUpdatingBooking, isCreating
     </Form>
   );
 
-  function onSubmit(values: z.infer<typeof formSchema>) {
+  async function onSubmit(values: z.infer<typeof formSchema>) {
     const fromDate = new Date(values.from);
     const toDate = new Date(values.to);
     fromDate.setHours(12, 0, 0, 0);
@@ -326,44 +339,43 @@ export function BookingForm({bookingValues, email, isUpdatingBooking, isCreating
       fullBooking.is_test_booking = true;
     }
 
-   if (isCreatingNewBooking) {
-    try {
-      createBooking(fullBooking, email);
-      setIsSending(true);
-    } catch {
-      toast({
-        title: "Något gick fel",
-        description: "På grund av ett fel kunde din bokning inte skapas. Försök igen senare.",
-      });
-      setIsSending(false);
+    setIsSending(true);
+
+    if (isCreatingNewBooking) {
+      try {
+        await createBooking(fullBooking, email);
+        if (!isDevelopment) {
+          await sendNotification(fullBooking);
+        }
+      } catch (error) {
+        // createBooking navigates away via redirect() on success, which surfaces
+        // here as a thrown NEXT_REDIRECT — let Next handle it rather than treating
+        // it as a failure.
+        if (isRedirectError(error)) {
+          throw error;
+        }
+        toast({
+          title: "Något gick fel",
+          description: "På grund av ett fel kunde din bokning inte skapas. Försök igen senare.",
+        });
+        setIsSending(false);
+      }
+    } else {
+      try {
+        await updateBooking(fullBooking);
+        toast({
+          title: "Bokning uppdaterad",
+          description: "Din bokning har uppdaterats.",
+        });
+        router.push(`/dashboard/profile`);
+      } catch {
+        toast({
+          title: "Något gick fel",
+          description: "På grund av ett fel kunde din bokning inte uppdateras. Försök igen senare.",
+        });
+        setIsSending(false);
+      }
     }
-    finally {
-      if (!isDevelopment) {
-        sendNotification(fullBooking)
-      } 
-      setIsSending(false);
-    }
-   } else {
-    try {
-      updateBooking(fullBooking);
-      setIsSending(true);
-    } 
-    catch {
-      toast({
-        title: "Något gick fel",
-        description: "På grund av ett fel kunde din bokning inte uppdateras. Försök igen senare.",
-      });
-      setIsSending(false);
-    }
-    finally {
-      toast({
-        title: "Boking uppdaterad",
-        description: "Din bokning har uppdaterats.",
-      });
-      setIsSending(false);
-      router.push(`/dashboard/profile`);
-    }
-   }
   }
 
   async function sendNotification(values: BookingFormValues) {


### PR DESCRIPTION
Fixes #15.

## Problem

`src/components/forms/booking/index.tsx` called the async server actions `createBooking`/`updateBooking` without `await`, so the surrounding `try/catch/finally` didn't behave as intended:

1. **Error toasts were dead code** — a rejected (unawaited) promise never reached the `catch`, so "Något gick fel" never fired.
2. **Failed updates reported success** — the update path's `finally` *always* showed the "Bokning uppdaterad" toast and navigated to `/dashboard/profile`, even when `updateBooking` threw.

## Fix

- Made `onSubmit` async and `await` both actions inside `try`.
- **Update path:** show the success toast and `router.push` only after a resolved `updateBooking`; on failure show the error toast and re-enable the button.
- **Create path:** send the push notification only on success (was firing in `finally` regardless of outcome); show the error toast on failure.
- Added an `isRedirectError` guard so `createBooking`'s `redirect()` — which surfaces client-side as a thrown `NEXT_REDIRECT` — is re-thrown for Next to handle rather than mistaken for a failure.
- Set `setIsSending(true)` at the start of submission so the submit button is disabled while the action runs.
- Fixed the "Boking" → "Bokning" typo in the success toast.

## Verification

- `tsc --noEmit`: no new errors in the file (pre-existing errors elsewhere are unrelated).
- `next lint` on the file: no warnings or errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)