### PR TITLE
Store dev-environment bookings in a dedicated DevBooking table (#22)

### DIFF
--- a/prisma/migrations/20260719105601_add_dev_table/migration.sql
+++ b/prisma/migrations/20260719105601_add_dev_table/migration.sql
@@ -1,0 +1,31 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `is_test_booking` on the `Booking` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Booking" DROP COLUMN "is_test_booking";
+
+-- CreateTable
+CREATE TABLE "DevBooking" (
+    "id" TEXT NOT NULL,
+    "created_at" BIGINT NOT NULL,
+    "updated_at" BIGINT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "booking_name" TEXT,
+    "name" TEXT NOT NULL,
+    "arrival" DATE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "departure" DATE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "guests" INTEGER NOT NULL,
+    "guests_children" INTEGER,
+    "rooms" TEXT[],
+    "message" TEXT,
+    "is_canceled" BOOLEAN DEFAULT false,
+    "is_rented_out" BOOLEAN DEFAULT false,
+
+    CONSTRAINT "DevBooking_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "DevBooking" ADD CONSTRAINT "DevBooking_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "AppUser"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -55,8 +55,9 @@ model AppUser {
   id         String          @id
   user_role  user_role_type? @default(user)
   avatar     Avatar?
-  family_id  String?        
+  family_id  String?
   bookings   Booking[]
+  dev_bookings DevBooking[]
   family     Family? @relation(fields: [family_id], references: [id])
   user_color String
   instance  clerk_instance? @default(production)
@@ -93,8 +94,27 @@ model Booking {
   rooms           String[]
   message         String?
   is_canceled     Boolean? @default(false)
-  is_test_booking Boolean? @default(false)
   is_rented_out  Boolean? @default(false)
+}
+
+// Bookings created while running in the dev environment live here so they never
+// mix with real production bookings. Mirrors the `Booking` shape exactly.
+model DevBooking {
+  id              String   @id @default(uuid())
+  created_at      BigInt
+  updated_at      BigInt
+  user            AppUser  @relation(fields: [user_id], references: [id])
+  user_id         String
+  booking_name    String?
+  name            String
+  arrival         DateTime @default(now()) @db.Date
+  departure       DateTime @default(now()) @db.Date
+  guests          Int
+  guests_children Int?
+  rooms           String[]
+  message         String?
+  is_canceled     Boolean? @default(false)
+  is_rented_out   Boolean? @default(false)
 }
 
 model Family {

--- a/src/app/dashboard/booking/[id]/page.tsx
+++ b/src/app/dashboard/booking/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { Main, Section } from "@/components/dashboard/sections";
 import { Button } from "@/components/ui/button";
 import { getRoomName, showGuests, showNiceDates } from "@/lib/functions";
-import { prisma } from "@/lib/prisma";
+import { bookingDb } from "@/lib/booking-db";
 import { getBookingName } from "@/lib/utils";
 import { auth } from "@clerk/nextjs/server";
 import { notFound } from "next/navigation";
@@ -16,7 +16,7 @@ export default async function UniqueBookingPage(props: {
   const params = await props.params;
   const id = params.id;
   const { userId } = await auth();
-  const booking = await prisma.booking.findUnique({
+  const booking = await bookingDb.findUnique({
     where: {
       id: id,
     },

--- a/src/app/dashboard/bookings/(calendar)/modal/(..)booking/[id]/page.tsx
+++ b/src/app/dashboard/bookings/(calendar)/modal/(..)booking/[id]/page.tsx
@@ -11,7 +11,7 @@ import { notFound } from "next/navigation";
 import { CancelBookingDialog } from "@/components/modal/cancel-booking";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
-import { prisma } from "@/lib/prisma";
+import { bookingDb } from "@/lib/booking-db";
 import Avatar from "@/components/avatar";
 import { NiceAvatarProps } from "@/components/avatar/types";
 import { auth } from "@clerk/nextjs/server";
@@ -27,10 +27,9 @@ export default async function UniqueBookingModalPage(props: {
   const params = await props.params;
   const id = params.id;
   const { userId } = await auth();
-  const booking = await prisma.booking.findUnique({
+  const booking = await bookingDb.findUnique({
     where: {
       id: id,
-      is_test_booking: false,
     },
     include: {
       user: {

--- a/src/app/dashboard/bookings/(calendar)/page.tsx
+++ b/src/app/dashboard/bookings/(calendar)/page.tsx
@@ -3,12 +3,12 @@ import CalendarProvider from "./context";
 import { CalendarView } from "./calendar-view";
 import { BookingsInView } from "./bookings-in-view";
 import { BookingEventSkeleton, CalendarSkeleton } from "@/components/skeletons";
-import { prisma } from "@/lib/prisma";
+import { bookingDb } from "@/lib/booking-db";
 import { BookingsFixedHeader } from "../bookings-header";
 import { NavSwitch } from "@/components/dashboard/nav-switch";
 
 export default async function CalendarPage() {
-  const bookings = await prisma.booking.findMany({
+  const bookings = await bookingDb.findMany({
     include: {
       user: {
         select: {
@@ -19,7 +19,6 @@ export default async function CalendarPage() {
     },
     where: {
       is_canceled: false,
-      is_test_booking: process.env.NODE_ENV === 'development',
     }
   });
 

--- a/src/app/dashboard/bookings/list/modal/(...)booking/[id]/page.tsx
+++ b/src/app/dashboard/bookings/list/modal/(...)booking/[id]/page.tsx
@@ -11,7 +11,7 @@ import { notFound } from "next/navigation";
 import { CancelBookingDialog } from "@/components/modal/cancel-booking";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
-import { prisma } from "@/lib/prisma";
+import { bookingDb } from "@/lib/booking-db";
 import Avatar from "@/components/avatar";
 import { NiceAvatarProps } from "@/components/avatar/types";
 import { auth } from "@clerk/nextjs/server";
@@ -27,10 +27,9 @@ export default async function UniqueBookingModalPage(props: {
   const params = await props.params;
   const id = params.id;
   const { userId } = await auth();
-  const booking = await prisma.booking.findUnique({
+  const booking = await bookingDb.findUnique({
     where: {
       id: id,
-      is_test_booking: false,
     },
     include: {
       user: {

--- a/src/app/dashboard/bookings/list/page.tsx
+++ b/src/app/dashboard/bookings/list/page.tsx
@@ -1,4 +1,4 @@
-import { prisma } from "@/lib/prisma";
+import { bookingDb } from "@/lib/booking-db";
 import BookingCard from "@/components/ui/booking-card";
 import { BookingsFixedHeader } from "../bookings-header";
 import { getMonthTitle, groupBookingsByMonth } from "@/lib/utils";
@@ -6,7 +6,7 @@ import { Typography } from "@/components/ui/typography";
 import { NavSwitch } from "@/components/dashboard/nav-switch";
 
 export default async function BookingsListPage() {
-  const bookings = await prisma.booking.findMany({
+  const bookings = await bookingDb.findMany({
     orderBy: {
       arrival: "desc"
     },
@@ -19,7 +19,6 @@ export default async function BookingsListPage() {
       },
       where: {
         is_canceled: false,
-        is_test_booking: false,
       }
     });
   

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -7,7 +7,7 @@ import FixedHeader from "@/components/dashboard/fixed-header";
 import Logo from "@/components/logo";
 import { Typography } from "@/components/ui/typography";
 import { Button } from "@/components/ui/button-primary";
-import { prisma } from "@/lib/prisma";
+import { bookingDb } from "@/lib/booking-db";
 import { currentUser } from "@clerk/nextjs/server";
 
 export default async function DashboardIndex() {
@@ -105,7 +105,7 @@ async function getBookingsDueWithin30Days() {
   thirtyDaysFromNow.setDate(today.getDate() + 30);
 
   // Query the database
-  const bookings = await prisma.booking.findMany({
+  const bookings = await bookingDb.findMany({
     take: 3,
     orderBy: {
       arrival: "asc",
@@ -121,7 +121,6 @@ async function getBookingsDueWithin30Days() {
       AND: [
         { 
           is_canceled: false,
-          is_test_booking: false, 
         }, // Exclude canceled bookings
         {
           arrival: {

--- a/src/app/dashboard/profile/@modal/(..)booking/[id]/page.tsx
+++ b/src/app/dashboard/profile/@modal/(..)booking/[id]/page.tsx
@@ -11,7 +11,7 @@ import { notFound } from "next/navigation";
 import { CancelBookingDialog } from "@/components/modal/cancel-booking";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
-import { prisma } from "@/lib/prisma";
+import { bookingDb } from "@/lib/booking-db";
 
 // Force dynamic page
 export const dynamic = "force-dynamic";
@@ -23,10 +23,9 @@ export default async function UniqueBookingModalPage(props: {
 }) {
   const params = await props.params;
   const id = params.id;
-  const booking = await prisma.booking.findUnique({
+  const booking = await bookingDb.findUnique({
     where: {
       id: id,
-      is_test_booking: false,
     },
     include: {
       user: {

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -1,6 +1,7 @@
 import FixedHeader from "@/components/dashboard/fixed-header";
 import { Typography } from "@/components/ui/typography";
 import { prisma } from "@/lib/prisma";
+import { bookingDb } from "@/lib/booking-db";
 import clsx from "clsx";
 import AvatarEdit from "./avatar-edit";
 import { sortBookingsByYear } from "@/lib/utils";
@@ -22,10 +23,9 @@ export default async function ProfilePage() {
         id: sessionClaims?.metadata.avatarId as string
       }
     }),
-    prisma.booking.findMany({
+    bookingDb.findMany({
       where: {
         user_id: userId as string,
-        is_test_booking: false,
       },
       include: {
         user: {

--- a/src/app/dashboard/start/@modal/(..)booking/[id]/page.tsx
+++ b/src/app/dashboard/start/@modal/(..)booking/[id]/page.tsx
@@ -11,7 +11,7 @@ import { notFound } from "next/navigation";
 import { CancelBookingDialog } from "@/components/modal/cancel-booking";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
-import { prisma } from "@/lib/prisma";
+import { bookingDb } from "@/lib/booking-db";
 import Avatar from "@/components/avatar";
 import { NiceAvatarProps } from "@/components/avatar/types";
 import { auth } from "@clerk/nextjs/server";
@@ -27,10 +27,9 @@ export default async function UniqueBookingModalPage(props: {
   const params = await props.params;
   const id = params.id;
   const { userId } = await auth();
-  const booking = await prisma.booking.findUnique({
+  const booking = await bookingDb.findUnique({
     where: {
       id: id,
-      is_test_booking: false,
     },
     include: {
       user: {

--- a/src/app/dashboard/statistics/page.tsx
+++ b/src/app/dashboard/statistics/page.tsx
@@ -1,5 +1,5 @@
 import FixedHeader from "@/components/dashboard/fixed-header";
-import { prisma } from "@/lib/prisma";
+import { bookingDb } from "@/lib/booking-db";
 import { cn } from "@/lib/utils";
 import { Tile } from "./tile";
 import { thisYear, getTotalGuestsThisYear, getTotalDaysThisYear } from './utils';
@@ -10,7 +10,7 @@ import { UserTable } from "./user-table";
 import { Typography } from "@/components/ui/typography";
 
 export default async function StatisticsPage() {
-  const bookings = await prisma.booking.findMany({
+  const bookings = await bookingDb.findMany({
     include: {
       user: {
         select: {
@@ -22,8 +22,7 @@ export default async function StatisticsPage() {
     where: {
       AND: [
         { 
-          is_canceled: false,
-          is_test_booking: false, }, // Exclude canceled bookings
+          is_canceled: false, }, // Exclude canceled bookings
       ],
     }
   });

--- a/src/components/forms/booking/action.ts
+++ b/src/components/forms/booking/action.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { BookingFormValues } from ".";
-import { prisma } from "@/lib/prisma";
+import { bookingDb } from "@/lib/booking-db";
 import { redirect } from "next/navigation";
 import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
 import { sendEmail } from "@/app/api/emails/sendEmail";
@@ -21,7 +21,7 @@ export async function createBooking(values: BookingFormValues, email: string | u
   const created_at = Date.now();
   const updated_at = Date.now();
 
-  await prisma.booking.create({
+  await bookingDb.create({
     data: {
       user_id,
       booking_name,
@@ -67,7 +67,7 @@ export async function updateBooking(values: BookingFormValues) {
     created_at,
   } = values;
   try {
-    await prisma.booking.update({
+    await bookingDb.update({
       where: {
         id: id,
       },

--- a/src/components/forms/booking/index.tsx
+++ b/src/components/forms/booking/index.tsx
@@ -61,7 +61,6 @@ export const formSchema = z.object({
   }),
   message: z.string().max(1000).optional(),
   is_rented_out: z.boolean().optional(),
-  is_test_booking: z.boolean().optional(),
 }).refine((data) => data.to > data.from, {
   message: "Slutdatumet måste vara efter startdatumet.",
   path: ["to"],
@@ -333,10 +332,6 @@ export function BookingForm({bookingValues, email, isUpdatingBooking, isCreating
       user_id: bookingValues?.user_id || "",
       created_at: bookingValues?.created_at,
       updated_at: bookingValues?.updated_at,
-    }
-
-    if (isDevelopment) {
-      fullBooking.is_test_booking = true;
     }
 
     setIsSending(true);

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -6,7 +6,7 @@ import { z } from "zod";
 import { CompleteRegistrationFormValues } from "./types";
 import { redirect } from "next/navigation";
 import { revalidatePath } from "next/cache";
-import { prisma } from "./prisma";
+import { bookingDb } from "./booking-db";
 
 const AvatarSchema = z.object({
   id: z.string(),
@@ -107,7 +107,7 @@ export async function createUser(data: CompleteRegistrationFormValues) {
 
 export async function cancelBooking(id: string) {
   try {
-    await prisma.booking.update({
+    await bookingDb.update({
       where: {
         id: id
       },
@@ -124,7 +124,7 @@ export async function cancelBooking(id: string) {
 }
 
 export async function fetchBooking(id: string) {
-  const booking = await prisma.booking.findUnique({
+  const booking = await bookingDb.findUnique({
     where: {
       id: id
     }

--- a/src/lib/booking-db.ts
+++ b/src/lib/booking-db.ts
@@ -1,0 +1,14 @@
+import { prisma } from "@/lib/prisma";
+
+/**
+ * Bookings made in the dev environment are stored in a dedicated `DevBooking`
+ * table so they never mix with real production bookings. Both models share the
+ * same shape, so we expose the environment-appropriate delegate under one name.
+ *
+ * In dev, every booking read and write goes to `DevBooking`; in production it
+ * goes to `Booking`. The cast keeps every call site typed against the production
+ * `Booking` model — safe because the two tables are structurally identical.
+ */
+export const bookingDb = (
+  process.env.NODE_ENV === "development" ? prisma.devBooking : prisma.booking
+) as typeof prisma.booking;


### PR DESCRIPTION
Closes #22.

## Problem

Dev-environment bookings landed in the same `Booking` table as real production bookings, separated only by an `is_test_booking` flag — which `createBooking` never actually persisted (`src/components/forms/booking/action.ts`). Reads were also inconsistent: the calendar scoped by environment (`is_test_booking: process.env.NODE_ENV === 'development'`) while every other page hardcoded `is_test_booking: false`, so in dev most views showed **production** data.

## Change

Route all booking reads and writes through a single environment-selected delegate.

- **`prisma/schema.prisma`** — add a `DevBooking` model mirroring `Booking`, add the `dev_bookings` back-relation on `AppUser`, and drop the now-unused `is_test_booking` column from `Booking`.
- **`src/lib/booking-db.ts`** (new) — `bookingDb` resolves to `prisma.devBooking` in development and `prisma.booking` in production, cast to the `Booking` delegate so call sites stay strongly typed.
- **14 call sites** — `createBooking`/`updateBooking`, `cancelBooking`/`fetchBooking`, and all 10 read pages (calendar, list, profile, statistics, dashboard, and the four modal `[id]` routes) now use `bookingDb`. Removed every `is_test_booking` where-clause.
- **Booking form** — removed `is_test_booking` from the Zod schema and the `onSubmit` dev-flag assignment.
- **Migration** `20260719105601_add_dev_table` — creates `DevBooking` (+ FK) and drops `is_test_booking`.

Result: **dev reads/writes hit `DevBooking` only; production hits `Booking` only.** Dev never shows production data and vice versa.

## Verification

- `prisma migrate dev` applied cleanly to the dev database.
- `prisma validate` ✅, `tsc --noEmit` (no new errors), `next lint` on changed files ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)